### PR TITLE
Upgrade translation-library from 1.6.0 to 1.7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "concrete5/community_translation": "2021.x-dev",
     "concrete5/core": "dev-develop",
     "doctrine/persistence": "^1",
-    "mlocati/concrete5-translation-library": "^1.6.0",
+    "mlocati/concrete5-translation-library": "^1.7.0",
     "concrete5/dependency-patches": "^1.4.0",
     "vlucas/phpdotenv": "^2.4",
     "concrete5/concrete_cms_theme": "dev-master"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2ef39cd86f6af2dbca86979c7a7e7278",
+    "content-hash": "ef8bf2c2ce20e37d0ba26710a4091345",
     "packages": [
         {
             "name": "anahkiasen/html-object",
@@ -4322,16 +4322,16 @@
         },
         {
             "name": "mlocati/concrete5-translation-library",
-            "version": "1.6.0",
+            "version": "1.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/concrete5-community/translation-library.git",
-                "reference": "4caccae6c1e28edbdccc619c527bd42dbedec331"
+                "reference": "1ecd6d3d0addf2406ca3992ee22f2351310ff0ad"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/concrete5-community/translation-library/zipball/4caccae6c1e28edbdccc619c527bd42dbedec331",
-                "reference": "4caccae6c1e28edbdccc619c527bd42dbedec331",
+                "url": "https://api.github.com/repos/concrete5-community/translation-library/zipball/1ecd6d3d0addf2406ca3992ee22f2351310ff0ad",
+                "reference": "1ecd6d3d0addf2406ca3992ee22f2351310ff0ad",
                 "shasum": ""
             },
             "require": {
@@ -4373,7 +4373,7 @@
                 "issues": "https://github.com/concrete5-community/translation-library/issues",
                 "source": "https://github.com/concrete5-community/translation-library"
             },
-            "time": "2020-04-21T10:13:21+00:00"
+            "time": "2021-11-01T20:41:15+00:00"
         },
         {
             "name": "mlocati/ip-lib",


### PR DESCRIPTION
This is required to correctly parse the new stuff included in the XML files of Concrete CMS v9.