### PR TITLE
Force PHP version, fix installing hautelook/phpass

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,8 @@
   "prefer-stable": true,
   "autoload": {
     "psr-4": {
-      "Concrete5\\Translate\\": "src"
+      "Concrete5\\Translate\\": "src",
+      "Hautelook\\Phpass\\": "vendor/hautelook/phpass/src/Hautelook/Phpass"
     }
   },
   "require": {

--- a/composer.json
+++ b/composer.json
@@ -17,14 +17,18 @@
     "mlocati/concrete5-translation-library": "^1.7.0",
     "concrete5/dependency-patches": "^1.4.0",
     "vlucas/phpdotenv": "^2.4",
-    "concrete5/concrete_cms_theme": "dev-master"
+    "concrete5/concrete_cms_theme": "dev-master",
+    "hautelook/phpass": "0.3.5"
   },
   "require-dev": {
     "phpunit/phpunit": "^8.0",
     "mockery/mockery": "^1.2"
   },
   "config": {
-    "preferred-install": "dist"
+    "preferred-install": "dist",
+    "platform": {
+      "php": "7.4.26"
+    }
   },
   "extra": {
     "allow-subpatches": [
@@ -54,6 +58,17 @@
           "url": "https://bitbucket.org/aembler/addon_markdown.git",
           "type": "git",
           "reference": "master"
+        }
+      }
+    },
+    "phpass": {
+      "type": "package",
+      "package": {
+        "name": "hautelook/phpass",
+        "version": "0.3.5",
+        "dist": {
+          "url": "https://codeload.github.com/ozh/phpass/zip/refs/tags/0.3.5",
+          "type": "zip"
         }
       }
     }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ef8bf2c2ce20e37d0ba26710a4091345",
+    "content-hash": "4fd348cf9e5579fbfe325c7f5a0dc06b",
     "packages": [
         {
             "name": "anahkiasen/html-object",
@@ -2727,50 +2727,11 @@
         {
             "name": "hautelook/phpass",
             "version": "0.3.5",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/hautelook/phpass.git",
-                "reference": "b4cbd9b67ed3ef5672ec79d8e0c46d24bd844abd"
-            },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/hautelook/phpass/zipball/b4cbd9b67ed3ef5672ec79d8e0c46d24bd844abd",
-                "reference": "b4cbd9b67ed3ef5672ec79d8e0c46d24bd844abd",
-                "shasum": ""
+                "url": "https://codeload.github.com/ozh/phpass/zip/refs/tags/0.3.5"
             },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-0": {
-                    "Hautelook": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "Public Domain"
-            ],
-            "authors": [
-                {
-                    "name": "Solar Designer",
-                    "email": "solar@openwall.com",
-                    "homepage": "http://openwall.com/phpass/"
-                }
-            ],
-            "description": "Portable PHP password hashing framework",
-            "homepage": "http://github.com/hautelook/phpass/",
-            "keywords": [
-                "blowfish",
-                "crypt",
-                "password",
-                "security"
-            ],
-            "support": {
-                "issues": "https://github.com/hautelook/phpass/issues",
-                "source": "https://github.com/hautelook/phpass/tree/0.3.x"
-            },
-            "time": "2012-08-31T00:00:00+00:00"
+            "type": "library"
         },
         {
             "name": "htmlawed/htmlawed",
@@ -11224,5 +11185,8 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
+    "platform-overrides": {
+        "php": "7.4.26"
+    },
     "plugin-api-version": "2.1.0"
 }


### PR DESCRIPTION
1. Since the Composer dependencies on the production server are controlled by the `composer.lock` file, we should be sure that `composer.lock` defines packages compatible with the production server &rarr; let's assume a specific PHP version
2. `hautelook/phpass` doesn't exist anymore: let's install it from a fork.