### PR TITLE
Don't require a specific commit of community_translation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   "require": {
     "composer/installers": "^1.3",
     "concrete5/community_badges_client": "dev-master",
-    "concrete5/community_translation": "dev-main#023cd38075690649958dcba28510c5012710ba14",
+    "concrete5/community_translation": "^1",
     "concrete5/concrete_cms_theme": "dev-master",
     "concrete5/core": "dev-develop as 9.x-dev",
     "concrete5/dependency-patches": "^1.6.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "aa72ac4460faa285d5db6360075ab3f7",
+    "content-hash": "032668f9e2b331c0e4c74fcc3fc0b8e6",
     "packages": [
         {
             "name": "anahkiasen/html-object",
@@ -376,23 +376,22 @@
         },
         {
             "name": "concrete5/community_translation",
-            "version": "dev-main",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/concrete5/addon_community_translation.git",
-                "reference": "023cd38075690649958dcba28510c5012710ba14"
+                "reference": "287494795d0b09f60fc491619cc70a207cf4fdf5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/concrete5/addon_community_translation/zipball/023cd38075690649958dcba28510c5012710ba14",
-                "reference": "023cd38075690649958dcba28510c5012710ba14",
+                "url": "https://api.github.com/repos/concrete5/addon_community_translation/zipball/287494795d0b09f60fc491619cc70a207cf4fdf5",
+                "reference": "287494795d0b09f60fc491619cc70a207cf4fdf5",
                 "shasum": ""
             },
             "require": {
                 "concrete5/core": "^9.0.3a1",
                 "php": "^7.4 || ^8"
             },
-            "default-branch": true,
             "type": "concrete5-package",
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -404,7 +403,7 @@
                 "issues": "https://github.com/concrete5/addon_community_translation/issues",
                 "source": "https://github.com/concrete5/addon_community_translation"
             },
-            "time": "2022-04-01T07:29:52+00:00"
+            "time": "2022-04-08T12:27:01+00:00"
         },
         {
             "name": "concrete5/concrete_cms_theme",
@@ -13078,7 +13077,6 @@
     "minimum-stability": "dev",
     "stability-flags": {
         "concrete5/community_badges_client": 20,
-        "concrete5/community_translation": 20,
         "concrete5/concrete_cms_theme": 20,
         "concrete5/core": 20
     },


### PR DESCRIPTION
I've [tagged](https://github.com/concrete5/addon_community_translation/commits/1.0.2) the most recent version of community_translation.
What about using it instead of a specific commit?

Why?

1. We already keep track of the exact commit to be used in the `composer.lock` file
2. Updating community_translation would be as easy as by running `composer update concrete5/community_translation`

PS: no other changes except using the tagged version: see https://github.com/concrete5/addon_community_translation/compare/023cd38075690649958dcba28510c5012710ba14...287494795d0b09f60fc491619cc70a207cf4fdf5