### PR TITLE
Move private package from composer to gitlab deploy 

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -80,6 +80,9 @@ build:tar:
     - *ssh_key_setup
     # Install production dependencies
     - composer install --no-dev --no-interaction --optimize-autoloader
+    # Load in the concrete_cms_auth package
+    - git clone --branch=1.0.1 git@gitlab.com:portlandlabs/addons/concrete_cms_auth.git
+    - rm -rf public/packages/concrete_cms_auth/.git
   script:
     # Delete anything we don't want to include in the tar
     - rm -rf tests resources

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,10 +5,6 @@ stages:
   - build
   - deploy
 
-cache:
-  paths:
-    - vendor/
-
 # Gitlab provided testing
 include:
   - template: SAST.gitlab-ci.yml
@@ -71,6 +67,13 @@ include:
 
 build:tar:
   stage: build
+  needs: []
+  cache:
+    - key:
+        files:
+          - composer.lock
+      paths:
+        - vendor/
   artifacts:
     paths:
       - release.tar.gz
@@ -81,7 +84,7 @@ build:tar:
     # Install production dependencies
     - composer install --no-dev --no-interaction --optimize-autoloader
     # Load in the concrete_cms_auth package
-    - git clone --branch=1.0.1 git@gitlab.com:portlandlabs/addons/concrete_cms_auth.git
+    - git clone --branch=1.0.1 https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.com/portlandlabs/addons/concrete_cms_auth.git
     - rm -rf public/packages/concrete_cms_auth/.git
   script:
     # Delete anything we don't want to include in the tar
@@ -92,6 +95,12 @@ build:tar:
 
 .job_template: &deploy
   stage: deploy
+  cache:
+    - key:
+        files:
+          - composer.lock
+      paths:
+        - vendor/
   before_script:
     - apt-get update && apt-get install gettext-base
     # Write GitLab Variables into the .codedeployvars file

--- a/README.md
+++ b/README.md
@@ -9,3 +9,9 @@ This repo contains the code for translation at concretecms.org.
 3. Install concrete5, making sure to select the `concrete_cms_translate` starting point. Here is an example of installation via the command line.
 
 `concrete/bin/concrete5 c5:install -vvv --db-server=localhost --db-database=concrete_cms_translate --db-username=user --db-password=password --starting-point=concrete_cms_translate --admin-email=your@email.com --admin-password=password`
+
+## Concrete CMS Auth package
+
+The `concrete_cms_auth` package is a private package that is included during deploy via `.gitlab-ci.yml`. If this 
+package needs updating, be sure to also update the `composer.json` to include any dependencies `concrete_cms_auth` may
+need.

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,10 @@
     "concretecms/community_translation": "^1",
     "concretecms/concrete_cms_theme": "dev-master",
     "mlocati/concrete5-translation-library": "^1.8",
-    "portlandlabs/concrete_cms_auth": "^1.0",
-    "vlucas/phpdotenv": "^2.4"
+    "vlucas/phpdotenv": "^2.4",
+    "ext-openssl": "*",
+    "aws/aws-sdk-php": "^1|^2|^3",
+    "league/uri-components": "^2|^7"
   },
   "require-dev": {
     "phpunit/phpunit": "^8.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dcfda85983dfb007b9ee3f2d7ced939e",
+    "content-hash": "1de3fa045a061697b6700d4fa2cff2f8",
     "packages": [
         {
             "name": "anahkiasen/html-object",
@@ -6951,62 +6951,6 @@
                 }
             ],
             "time": "2022-12-17T18:26:50+00:00"
-        },
-        {
-            "name": "portlandlabs/concrete_cms_auth",
-            "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "git@gitlab.com:portlandlabs/addons/concrete_cms_auth.git",
-                "reference": "e3aa84c7abd18b2d304e7e47580a250372fc09fe"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://gitlab.com/api/v4/projects/portlandlabs%2Faddons%2Fconcrete_cms_auth/repository/archive.zip?sha=e3aa84c7abd18b2d304e7e47580a250372fc09fe",
-                "reference": "e3aa84c7abd18b2d304e7e47580a250372fc09fe",
-                "shasum": ""
-            },
-            "require": {
-                "aws/aws-sdk-php": "^1|^2|^3",
-                "ext-openssl": "*",
-                "league/uri-components": "^2|^7"
-            },
-            "require-dev": {
-                "concrete5/core": "^9",
-                "laravel/pint": "^1.17",
-                "mockery/mockery": "^1.6",
-                "pestphp/pest": "^1.23"
-            },
-            "type": "concrete5-package",
-            "autoload": {
-                "psr-4": {
-                    "PortlandLabs\\CommunityAuth\\": "src"
-                },
-                "files": [
-                    "src/helpers.php"
-                ]
-            },
-            "scripts": {
-                "lint": [
-                    "pint"
-                ],
-                "test:lint": [
-                    "@lint -- --test"
-                ],
-                "test:unit": [
-                    "pest"
-                ],
-                "test": [
-                    "@test:lint",
-                    "@test:unit"
-                ]
-            },
-            "description": "Concrete community authentication package",
-            "support": {
-                "source": "https://gitlab.com/portlandlabs/addons/concrete_cms_auth/-/tree/1.0.1",
-                "issues": "https://gitlab.com/portlandlabs/addons/concrete_cms_auth/-/issues"
-            },
-            "time": "2024-08-30T02:02:59+00:00"
         },
         {
             "name": "predis/predis",
@@ -14014,7 +13958,8 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.2"
+        "php": "^8.2",
+        "ext-openssl": "*"
     },
     "platform-dev": {},
     "plugin-api-version": "2.6.0"


### PR DESCRIPTION
This PR changes the way `concrete_cms_auth` is loaded in order to maintain @mlocati's and other contributor's ability to effectively update / modify composer dependencies.

The issue with having this private package in `composer.json` is it prevents anyone without access to the private repository from installing dependencies fully or updating dependencies. Now that the private package is outside of composer, contributors can make changes to [`concretecms/addon_community_translation`](https://github.com/concretecms/addon_community_translation) and also guide their inclusion here in this project.
