### PR TITLE
git-ignore local configuration files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@
 /build
 /.phpunit.*
 .DS_Store
+
+# Ignore local configuration files
+/public/application/config/local.*.php


### PR DESCRIPTION
I'm developing using a local web server that's running via HTTP and not HTTPS.
So, since we have that session cookies [have the `secure` flag](https://github.com/concretecms/translate.concretecms.org/blob/db1034c205f8e0a65f362dcaca464e1e5b44159a/public/application/config/concrete.php#L10), I'm not able to login.

To fix it, I've defined a `CONCRETE5_ENV` environment variable with value `local`, and created the file `public/application/config/local.concrete.php` with this content:

```php
<?php

return [
    'session' => [
        'cookie' => [
            'cookie_secure' => false,
            'cookie_samesite' => 'Lax',
        ],
    ],
];
```

What about git-ignoring `public/application/config/local.*.php` files?